### PR TITLE
Addition of two arxiv papers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ Blanchard, Gilles, Gyemin Lee, and Clayton Scott.
 
 ### arXiv
 
+- (**Rex**) [Out-of-distribution generalization via risk extrapolation](https://arxiv.org/abs/2003.00688)    
+Krueger, David, Ethan Caballero, Joern-Henrik Jacobsen, Amy Zhang, Jonathan Binas, Remi Le Priol, and Aaron Courville.
+*arXiv preprint arXiv:2003.00688* (2020).  
+
+- [Risk Variance Penalization: From Distributional Robustness to Causality](https://arxiv.org/abs/2006.07544)    
+Xie, Chuanlong, Fei Chen, Yue Liu, and Zhenguo Li. 
+*arXiv preprint arXiv:2006.07544 * (2020).  
+
 - [Generalization and Invariances in the Presence of Unobserved Confounding](https://arxiv.org/abs/2007.10653)  
 Bellot, Alexis and van der Schaar, Mihaela.  
 *arXiv preprint arXiv:2007.10653* (2020).  

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Krueger, David, Ethan Caballero, Joern-Henrik Jacobsen, Amy Zhang, Jonathan Bina
 
 - [Risk Variance Penalization: From Distributional Robustness to Causality](https://arxiv.org/abs/2006.07544)    
 Xie, Chuanlong, Fei Chen, Yue Liu, and Zhenguo Li.    
-*arXiv preprint arXiv:2006.07544 * (2020).  
+*arXiv preprint arXiv:2006.07544* (2020).  
 
 - [Generalization and Invariances in the Presence of Unobserved Confounding](https://arxiv.org/abs/2007.10653)  
 Bellot, Alexis and van der Schaar, Mihaela.  

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ Blanchard, Gilles, Gyemin Lee, and Clayton Scott.
 ### arXiv
 
 - (**Rex**) [Out-of-distribution generalization via risk extrapolation](https://arxiv.org/abs/2003.00688)    
-Krueger, David, Ethan Caballero, Joern-Henrik Jacobsen, Amy Zhang, Jonathan Binas, Remi Le Priol, and Aaron Courville.
+Krueger, David, Ethan Caballero, Joern-Henrik Jacobsen, Amy Zhang, Jonathan Binas, Remi Le Priol, and Aaron Courville.  
 *arXiv preprint arXiv:2003.00688* (2020).  
 
 - [Risk Variance Penalization: From Distributional Robustness to Causality](https://arxiv.org/abs/2006.07544)    
-Xie, Chuanlong, Fei Chen, Yue Liu, and Zhenguo Li. 
+Xie, Chuanlong, Fei Chen, Yue Liu, and Zhenguo Li.    
 *arXiv preprint arXiv:2006.07544 * (2020).  
 
 - [Generalization and Invariances in the Presence of Unobserved Confounding](https://arxiv.org/abs/2007.10653)  


### PR DESCRIPTION
Added the following papers:

- Risk Variance Penalization: From Distributional Robustness to Causality
- Out-of-Distribution Generalization via Risk Extrapolation (REx)
